### PR TITLE
Enabled http requests to youtube.com and its subdomains

### DIFF
--- a/iOS Client/Info.plist
+++ b/iOS Client/Info.plist
@@ -38,5 +38,23 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>youtube.com</key>
+            <dict>
+                <!--Include to allow subdomains-->
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <!--Include to allow HTTP requests-->
+                <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <!--Include to specify minimum TLS version-->
+                <key>NSTemporaryExceptionMinimumTLSVersion</key>
+                <string>TLSv1.1</string>
+            </dict>
+        </dict>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
This makes all the videos show up. Youtube ones play inline as expected. If they're from vevo, then the user gets an error message when they click play. Don't see a good workaround at the moment b/c wkwebview doesn't let us specify a sticky, global http referer header. All the solutions I've found are hacks and using deprecated APIs like UIWebView, so I guess we'll live with this for now . . .