### PR TITLE
Fixed Core Data Concurrency Issues 

### DIFF
--- a/iOS Client/AppDelegate/AppDelegate.swift
+++ b/iOS Client/AppDelegate/AppDelegate.swift
@@ -51,19 +51,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         UserDefaults.standard.set(Date().timeIntervalSinceReferenceDate, forKey: MBConstants.DEFAULTS_KEY_BACKGROUND_APP_REFRESH_ATTEMPT_TIMESTAMP)
         
-        guard let managedContext = self.persistentContainer?.viewContext else {
+        guard let persistentContainer = self.persistentContainer else {
             completionHandler(.failed)
             return
         }
         
-        MBStore().syncAllData(context: managedContext) { (isNewData: Bool, syncErr: Error?) in
+        MBStore().syncAllData(persistentContainer: persistentContainer) { (isNewData: Bool?, syncErr: Error?) in
             if syncErr != nil {
                 completionHandler(.failed)
             } else {
                 let timestamp: Double = Date().timeIntervalSinceReferenceDate
                 UserDefaults.standard.set(timestamp, forKey: MBConstants.DEFAULTS_KEY_ARTICLE_UPDATE_TIMESTAMP)
                 UserDefaults.standard.set(timestamp, forKey: MBConstants.DEFAULTS_KEY_BACKGROUND_APP_REFRESH_TIMESTAMP)
-                if isNewData == true {
+                if let isNewDataUnwrapped = isNewData, isNewDataUnwrapped == true {
                     // TODO: Run Data Cleanup Task
                     completionHandler(.newData)
                 } else {

--- a/iOS Client/Models/MBAuthor+CoreDataProperties.swift
+++ b/iOS Client/Models/MBAuthor+CoreDataProperties.swift
@@ -1,9 +1,8 @@
 //
 //  MBAuthor+CoreDataProperties.swift
-//  iOS Client
 //
-//  Created by Alex Ramey on 10/5/17.
-//  Copyright © 2017 Mockingbird. All rights reserved.
+//
+//  Created by Alex Ramey on 11/4/17.
 //
 //
 
@@ -12,7 +11,7 @@ import CoreData
 
 
 extension MBAuthor {
-
+    
     @nonobjc public class func fetchRequest() -> NSFetchRequest<MBAuthor> {
         return NSFetchRequest<MBAuthor>(entityName: "Author")
     }
@@ -20,5 +19,24 @@ extension MBAuthor {
     @NSManaged public var authorID: Int32
     @NSManaged public var info: String?
     @NSManaged public var name: String?
-
+    @NSManaged public var articles: NSSet?
+    
 }
+
+// MARK: Generated accessors for articles
+extension MBAuthor {
+    
+    @objc(addArticlesObject:)
+    @NSManaged public func addToArticles(_ value: MBArticle)
+    
+    @objc(removeArticlesObject:)
+    @NSManaged public func removeFromArticles(_ value: MBArticle)
+    
+    @objc(addArticles:)
+    @NSManaged public func addToArticles(_ values: NSSet)
+    
+    @objc(removeArticles:)
+    @NSManaged public func removeFromArticles(_ values: NSSet)
+    
+}
+

--- a/iOS Client/Models/MBCategory+CoreDataProperties.swift
+++ b/iOS Client/Models/MBCategory+CoreDataProperties.swift
@@ -1,9 +1,8 @@
 //
 //  MBCategory+CoreDataProperties.swift
-//  iOS Client
 //
-//  Created by Alex Ramey on 10/5/17.
-//  Copyright © 2017 Mockingbird. All rights reserved.
+//
+//  Created by Alex Ramey on 11/4/17.
 //
 //
 
@@ -12,13 +11,32 @@ import CoreData
 
 
 extension MBCategory {
-
+    
     @nonobjc public class func fetchRequest() -> NSFetchRequest<MBCategory> {
         return NSFetchRequest<MBCategory>(entityName: "Category")
     }
-
+    
     @NSManaged public var categoryID: Int32
     @NSManaged public var name: String?
     @NSManaged public var parent: Int32
-
+    @NSManaged public var articles: NSSet?
+    
 }
+
+// MARK: Generated accessors for articles
+extension MBCategory {
+    
+    @objc(addArticlesObject:)
+    @NSManaged public func addToArticles(_ value: MBArticle)
+    
+    @objc(removeArticlesObject:)
+    @NSManaged public func removeFromArticles(_ value: MBArticle)
+    
+    @objc(addArticles:)
+    @NSManaged public func addToArticles(_ values: NSSet)
+    
+    @objc(removeArticles:)
+    @NSManaged public func removeFromArticles(_ values: NSSet)
+    
+}
+

--- a/iOS Client/Store/MBStore.swift
+++ b/iOS Client/Store/MBStore.swift
@@ -50,15 +50,12 @@ class MBStore: NSObject {
     /***** Download Data from Network (MAY BE INVOKED FROM ANY THREAD) *****/
     func syncAllData(persistentContainer: NSPersistentContainer, completion: @escaping (Bool?, Error?) -> Void) {
         var isNewData: Bool = false
-        
         downloadAuthors(persistentContainer: persistentContainer) { (isNewAuthorData, authorsErr) in
-            isNewData = isNewAuthorData ?? false
             if let unwrappedAuthorsErr = authorsErr {
                 print("There was an error downloading author data! \(unwrappedAuthorsErr)")
                 completion(nil, authorsErr)
             } else {
                 self.downloadCategories(persistentContainer: persistentContainer, completion: { (isNewCategoryData, catErr) in
-                    isNewData = isNewAuthorData ?? false || isNewCategoryData ?? false
                     if let unwrappedCatErr = catErr {
                         print("There was an error downloading category data! \(unwrappedCatErr)")
                         completion(nil, catErr)


### PR DESCRIPTION
Per this discussion:
https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CoreData/Concurrency.html
"
```
When you are using an NSPersistentContainer, the viewContext property is configured as a NSMainQueueConcurrencyType context and the contexts associated with performBackgroundTask: and newBackgroundContext are configured as NSPrivateQueueConcurrencyType.
```
"

I realized we were using the PersistentContainer's `viewContext` property in threads other than the main thread. This is not allowed, and caused crashes randomly. This was reproducible when simulating a background app refresh while playing a safari youtube video in the foreground to force the background task to take place on a background thread.

The solution was to use the container's `performBackgroundTask` method to safely manipulate objects in the background threads. 

Note: Only call MBStore's `getArticles`, `getAuthors`, `getCategories` from the main thread, b/c they assume it's safe to use the `viewContext` of the persistentContainer
