### PR TITLE
1. Group articles by category in the table view

### DIFF
--- a/iOS Client/ArticlesController/ArticleTableViewCell.swift
+++ b/iOS Client/ArticlesController/ArticleTableViewCell.swift
@@ -38,12 +38,13 @@ class ArticleTableViewCell: UITableViewCell {
                 }
             }
         }
+        self.coverImage.image = nil
         titleLabel.attributedText = title
         titleLabel.font = UIFont.systemFont(ofSize: 18)
         titleLabel.textColor = UIColor.ArticleTitle
         authorLabel.attributedText = author
         authorLabel.font = UIFont.boldSystemFont(ofSize: 15)
-        snippetLabel.text = snippet
+        snippetLabel.text = ""//snippet
     }
     
 }

--- a/iOS Client/ArticlesController/MBArticlesViewController.swift
+++ b/iOS Client/ArticlesController/MBArticlesViewController.swift
@@ -12,9 +12,8 @@ import CoreData
 
 class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, StoreSubscriber {
     @IBOutlet weak var tableView: UITableView!
-    var articles: [MBArticle] = []
-    var attributedTitles: [NSAttributedString] = []
-    var attributedAuthors: [NSAttributedString] = []
+    var articlesByCategory = [String: [MBArticle]]()
+    var topLevelCategories: [String] = []
     let client = MBClient()
     static let ArticleTableViewCellId = "ArticleTableViewCell"
     
@@ -42,11 +41,6 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
         tableView.register(UINib(nibName: MBArticlesViewController.ArticleTableViewCellId, bundle: nil), forCellReuseIdentifier: MBArticlesViewController.ArticleTableViewCellId)
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = CGFloat(MBConstants.ARTICLE_TABLEVIEWCELL_HEIGHT)
-        
-        
-        // Set up a bar button item to toggle debug info on background app refresh
-        let item = UIBarButtonItem(barButtonSystemItem: .refresh, target: self, action: #selector(MBArticlesViewController.showTimestamps))
-        self.navigationItem.setRightBarButton(item, animated: false)
         
         // 1. the managed context has to be passed in (UIApplication should only be accessed from main thread)
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
@@ -109,73 +103,84 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
         case .error:
             print("Error: Loading articles")
         case .loaded(let data):
-            if data.count != articles.count {
-                print("New Data for table view")
-                articles = data
-                attributedTitles = articles.flatMap{ $0.title?.convertHtml() }
-                attributedAuthors = articles.flatMap{ $0.author?.name?.convertHtml() }
-                tableView.reloadData()
+            print("New Data for table view")
+            articlesByCategory = groupArticlesByTopLevelCategoryName(articles: data)
+            topLevelCategories = Array(articlesByCategory.keys)
+            tableView.reloadData()
+        }
+    }
+    
+    private func groupArticlesByTopLevelCategoryName(articles: [MBArticle]) -> [String: [MBArticle]] {
+        var retVal = [String: [MBArticle]]()
+        
+        articles.forEach { (article) in
+            if let categories = article.categories {
+                let topLevelCategories = Set(categories.flatMap({ (category) -> String? in
+                    return (category as? MBCategory)?.getTopLevelCategory()?.name
+                }))
+            
+                for topLevelCategory in topLevelCategories {
+                    if let _ = retVal[topLevelCategory] {
+                        retVal[topLevelCategory]?.append(article)
+                    } else {
+                        retVal[topLevelCategory] = [article]
+                    }
+                }
+                
+                if topLevelCategories.count == 0 {
+                    print("Excluding article! \(article.title ?? "<no title>") b/c it has no categories")
+                }
+            } else {
+                print("Excluding article \(article.title ?? "<no title>") b/c it has no categories")
             }
         }
+        return retVal
     }
     
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-    
-    // MARK: - showTimestamps() is used for debug purposes
-    @objc func showTimestamps() {
-        let lastOverallUpdate = UserDefaults.standard.double(forKey: MBConstants.DEFAULTS_KEY_ARTICLE_UPDATE_TIMESTAMP)
-        let lastBackgroundUpdate = UserDefaults.standard.double(forKey: MBConstants.DEFAULTS_KEY_BACKGROUND_APP_REFRESH_TIMESTAMP)
-        let lastBackgroundAttempt = UserDefaults.standard.double(forKey: MBConstants.DEFAULTS_KEY_BACKGROUND_APP_REFRESH_ATTEMPT_TIMESTAMP)
-        
-        let lastOverallUpdateDate = Date(timeIntervalSinceReferenceDate: lastOverallUpdate)
-        let lastBackgroundUpdateDate = Date(timeIntervalSinceReferenceDate: lastBackgroundUpdate)
-        let lastBackgroundAttemptDate = Date(timeIntervalSinceReferenceDate: lastBackgroundAttempt)
-        
-        let dateFormatter = DateFormatter()
-        if let timeZone = TimeZone(identifier: "America/New_York") {
-            dateFormatter.timeZone = timeZone
-        }
-        dateFormatter.locale = NSLocale.current
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
-        
-        let msg = "Last Update: \(dateFormatter.string(from: lastOverallUpdateDate))\nLast Background Refresh: \(dateFormatter.string(from: lastBackgroundUpdateDate))\nLast Background Attempt: \(dateFormatter.string(from: lastBackgroundAttemptDate))"
-        
-        let ac = UIAlertController(title: "DEBUG", message: msg, preferredStyle: .actionSheet)
-        ac.addAction(UIAlertAction(title: "👍", style: .default, handler: nil))
-        self.present(ac, animated: true, completion: nil)
-    }
 }
 
-// MARK: - UITableViewDataSource
 extension MBArticlesViewController {
+    // MARK: - UITableViewDataSource
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return articles.count
+        return articlesByCategory[topLevelCategories[section]]!.count
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        return topLevelCategories.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let article = articles[indexPath.row]
+        let article = articlesByCategory[topLevelCategories[indexPath.section]]![indexPath.row]
+        
         if let cell = tableView.dequeueReusableCell(withIdentifier: MBArticlesViewController.ArticleTableViewCellId) as? ArticleTableViewCell {
             let snippetEndIndex = article.content?.index(article.content!.startIndex, offsetBy: 200)
             let snippet = String(article.content!.prefix(through: snippetEndIndex!))
-            cell.configure(title: attributedTitles[indexPath.row], author: attributedAuthors[indexPath.row], snippet: snippet, imageId: article.imageID, client: client, indexPath: indexPath)
+            cell.configure(title: article.title?.convertHtml(), author: article.author?.name?.convertHtml(), snippet: snippet, imageId: article.imageID, client: client, indexPath: indexPath)
             return cell
         } else {
             return UITableViewCell()
         }
     }
-    
+
+    // MARK: - UITableViewDelegate
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let selectedArticle = articles[indexPath.row]
+        let selectedArticle = articlesByCategory[topLevelCategories[indexPath.section]]![indexPath.row]
         let action = SelectedArticle(article: selectedArticle)
         MBStore.sharedStore.dispatch(action)
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 30))
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 30))
+        label.text = topLevelCategories[section]
+        view.addSubview(label)
+        view.backgroundColor = UIColor.orange
+        return view
     }
 }
 

--- a/iOS Client/HTTPClient/MBClient.swift
+++ b/iOS Client/HTTPClient/MBClient.swift
@@ -26,7 +26,7 @@ class MBClient: NSObject {
         config.allowsCellularAccess = true
         config.httpAdditionalHeaders = ["Accept": "application/json"]
         self.session = URLSession(configuration: config)
-        urlArgs = "?page=1&per_page=\(numResultsPerPage)&offset="
+        urlArgs = "?per_page=\(numResultsPerPage)&page="
         
         super.init()
     }
@@ -77,9 +77,9 @@ class MBClient: NSObject {
     // and optionally an error if one occurred at any point in the process.
     func getCategoriesWithCompletion(completion: @escaping ([Data], Error?) -> Void ) {
         let urlString = "\(baseURL)\(categoriesEndpoint)\(urlArgs)"
-        let urlStringWithOffsetZero = "\(urlString)0"
-        guard let url = URL(string: urlStringWithOffsetZero) else {
-            completion([], NetworkRequestError.invalidURL(url: urlStringWithOffsetZero))
+        let urlStringWithPageOne = "\(urlString)1"
+        guard let url = URL(string: urlStringWithPageOne) else {
+            completion([], NetworkRequestError.invalidURL(url: urlStringWithPageOne))
             return
         }
         
@@ -96,9 +96,9 @@ class MBClient: NSObject {
     // and optionally an error if one occurred at any point in the process.
     func getAuthorsWithCompletion(completion: @escaping ([Data], Error?) -> Void ) {
         let urlString = "\(baseURL)\(authorsEndpoint)\(urlArgs)"
-        let urlStringWithOffsetZero = "\(urlString)0"
-        guard let url = URL(string: urlStringWithOffsetZero) else {
-            completion([], NetworkRequestError.invalidURL(url: urlStringWithOffsetZero))
+        let urlStringWithPageOne = "\(urlString)1"
+        guard let url = URL(string: urlStringWithPageOne) else {
+            completion([], NetworkRequestError.invalidURL(url: urlStringWithPageOne))
             return
         }
         
@@ -213,8 +213,8 @@ class MBClient: NSObject {
         
         var dataTasks: [URLSessionDataTask] = []
         var results: [Data?] = [data]
-        for i in 1...numPages {
-            let urlString = "\(url)\(i*self.numResultsPerPage)"
+        for i in 2...numPages {
+            let urlString = "\(url)\(i)"
             guard let url = URL(string: urlString) else {
                 completion([], NetworkRequestError.invalidURL(url: urlString))
                 return

--- a/iOS Client/Models/MBCategory+CoreDataProperties.swift
+++ b/iOS Client/Models/MBCategory+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  MBCategory+CoreDataProperties.swift
 //
 //
-//  Created by Alex Ramey on 11/4/17.
+//  Created by Alex Ramey on 11/14/17.
 //
 //
 
@@ -18,8 +18,9 @@ extension MBCategory {
     
     @NSManaged public var categoryID: Int32
     @NSManaged public var name: String?
-    @NSManaged public var parent: Int32
+    @NSManaged public var parentID: Int32
     @NSManaged public var articles: NSSet?
+    @NSManaged public var parent: MBCategory?
     
 }
 
@@ -39,4 +40,3 @@ extension MBCategory {
     @NSManaged public func removeFromArticles(_ values: NSSet)
     
 }
-

--- a/iOS Client/Models/MBCategory+Custom.swift
+++ b/iOS Client/Models/MBCategory+Custom.swift
@@ -48,9 +48,20 @@ extension MBCategory {
         }
         
         category.setValue(json.object(forKey: "id") as? Int32, forKey: "categoryID")
-        category.setValue(json.object(forKey: "parent") as? Int32, forKey: "parent")
+        category.setValue(json.object(forKey: "parent") as? Int32, forKey: "parentID")
         category.setValue(json.object(forKey: "name") as? String, forKey: "name")
         return isNewData
     }
     
+    // There are multiple top-level categories (whose parentID is 0). The rest are children.
+    // This method follows the parent links until it encounters a top-level category,
+    // which it returns. If called on a top-level category, this method returns the
+    // receiver.
+    public func getTopLevelCategory() -> MBCategory? {
+        if self.parentID == 0 {
+            return self
+        } else {
+            return self.parent?.getTopLevelCategory() ?? nil
+        }
+    }
 }

--- a/iOS Client/Store/MBStore.swift
+++ b/iOS Client/Store/MBStore.swift
@@ -61,13 +61,20 @@ class MBStore: NSObject {
                         print("There was an error downloading category data! \(unwrappedCatErr)")
                         completion(nil, catErr)
                     } else {
-                        self.downloadArticles(persistentContainer: persistentContainer, completion: { (isNewArticleData, articleErr) in
-                            isNewData = isNewAuthorData ?? false || isNewCategoryData ?? false || isNewArticleData ?? false
-                            if let unwrappedArticleErr = articleErr {
-                                print("There was an error downloading article data! \(unwrappedArticleErr)")
-                                completion(nil, articleErr)
+                        self.linkCategoriesTogether(persistentContainer: persistentContainer, completion: { (linkErr) in
+                            if let unwrappedLinkErr = linkErr {
+                                print("There was an error linking categories! \(unwrappedLinkErr)")
+                                completion(nil, linkErr)
                             } else {
-                                completion(isNewData, nil)
+                                self.downloadArticles(persistentContainer: persistentContainer, completion: { (isNewArticleData, articleErr) in
+                                    isNewData = isNewAuthorData ?? false || isNewCategoryData ?? false || isNewArticleData ?? false
+                                    if let unwrappedArticleErr = articleErr {
+                                        print("There was an error downloading article data! \(unwrappedArticleErr)")
+                                        completion(nil, articleErr)
+                                    } else {
+                                        completion(isNewData, nil)
+                                    }
+                                })
                             }
                         })
                     }
@@ -81,6 +88,28 @@ class MBStore: NSObject {
     func syncDevotions(completion: @escaping ([MBDevotion]?, Error?) -> Void) {
         loadDevotions { (devotions, devotionError) in
             completion(devotions, devotionError)
+        }
+    }
+    
+    private func linkCategoriesTogether(persistentContainer: NSPersistentContainer, completion: @escaping (Error?) -> Void) {
+        persistentContainer.performBackgroundTask { (managedContext) in
+            let fetchRequest: NSFetchRequest<MBCategory> = MBCategory.fetchRequest()
+            fetchRequest.sortDescriptors = [NSSortDescriptor(key: "parentID", ascending: true)]
+            do {
+                let fetchedCategories = try managedContext.fetch(fetchRequest) as [MBCategory]
+                var categoriesByID = [Int32: MBCategory]()
+                fetchedCategories.forEach({ (category) in
+                    categoriesByID[category.categoryID] = category
+                })
+                fetchedCategories.forEach({ (category) in
+                    category.parent = categoriesByID[category.parentID]
+                })
+                try managedContext.save()
+                completion(nil)
+            } catch {
+                print("Could not fetch. \(error)")
+                completion(error)
+            }
         }
     }
 

--- a/iOS Client/iOS_Client.xcdatamodeld/iOS_Client.xcdatamodel/contents
+++ b/iOS Client/iOS_Client.xcdatamodeld/iOS_Client.xcdatamodel/contents
@@ -19,12 +19,13 @@
     <entity name="Category" representedClassName=".MBCategory" syncable="YES">
         <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="parent" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="articles" optional="YES" toMany="YES" deletionRule="Deny" destinationEntity="Article" inverseName="categories" inverseEntity="Article" syncable="YES"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Category" syncable="YES"/>
     </entity>
     <elements>
         <element name="Article" positionX="-63" positionY="-18" width="128" height="165"/>
         <element name="Author" positionX="-36" positionY="45" width="128" height="103"/>
-        <element name="Category" positionX="-54" positionY="18" width="128" height="103"/>
+        <element name="Category" positionX="-54" positionY="18" width="128" height="120"/>
     </elements>
 </model>


### PR DESCRIPTION
I left comments throughout to annotate things.

The big pieces of this PR are:
1) Added `parent` relationship from category to category (one to one)
2) Link up the categories after downloading them all (set parent to point to the correct parent)
3) Helper instance method on MBCategory to get its Top-Level Category (walk up the tree to a root)
4) ArticlesViewController uses this infrastructure to group articles by top-level category name
5) bug fixes in http client (I was doing paging wrong)
6) Custom section header views to label each section
7) Tweaks to custom cell to make it display nicer for now
8) Removed debug utility