### PR TITLE
1. Rolled own Core Data Stack 2. Pass managed context from app delegate

### DIFF
--- a/iOS Client.xcodeproj/project.pbxproj
+++ b/iOS Client.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		D02525641FD78E5B009980BB /* ArticleItem.xib in Resources */ = {isa = PBXBuildFile; fileRef = D02525631FD78E5B009980BB /* ArticleItem.xib */; };
 		D02C22911FDD84820024D0F6 /* MBArticlesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02C22901FDD84820024D0F6 /* MBArticlesStore.swift */; };
 		D02C22931FDD85F30024D0F6 /* MBDevotionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02C22921FDD85F30024D0F6 /* MBDevotionsStore.swift */; };
+		D02C22971FDE15120024D0F6 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02C22961FDE15120024D0F6 /* CoreDataStack.swift */; };
 		D02D363B1F7FDFB500D4E674 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02D363A1F7FDFB500D4E674 /* AppCoordinator.swift */; };
 		D02D363D1F7FE19400D4E674 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02D363C1F7FE19400D4E674 /* Coordinator.swift */; };
 		D02D36401F7FE5A800D4E674 /* ArticlesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02D363F1F7FE5A800D4E674 /* ArticlesCoordinator.swift */; };
@@ -84,6 +85,7 @@
 		D02525631FD78E5B009980BB /* ArticleItem.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ArticleItem.xib; sourceTree = "<group>"; };
 		D02C22901FDD84820024D0F6 /* MBArticlesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBArticlesStore.swift; sourceTree = "<group>"; };
 		D02C22921FDD85F30024D0F6 /* MBDevotionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBDevotionsStore.swift; sourceTree = "<group>"; };
+		D02C22961FDE15120024D0F6 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		D02D363A1F7FDFB500D4E674 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppCoordinator.swift; path = "iOS Client/TabController/AppCoordinator.swift"; sourceTree = SOURCE_ROOT; };
 		D02D363C1F7FE19400D4E674 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		D02D363F1F7FE5A800D4E674 /* ArticlesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ArticlesCoordinator.swift; path = "iOS Client/ArticlesController/ArticlesCoordinator.swift"; sourceTree = SOURCE_ROOT; };
@@ -221,6 +223,14 @@
 			path = CollectionViewCell;
 			sourceTree = "<group>";
 		};
+		D02C22951FDE14E40024D0F6 /* CoreDataStack */ = {
+			isa = PBXGroup;
+			children = (
+				D02C22961FDE15120024D0F6 /* CoreDataStack.swift */,
+			);
+			path = CoreDataStack;
+			sourceTree = "<group>";
+		};
 		D02D36391F7C9FBF00D4E674 /* TabController */ = {
 			isa = PBXGroup;
 			children = (
@@ -286,6 +296,7 @@
 				D0DDEC3C1F7C812F007822CB /* BookmarksController */,
 				D00F8F591F93F122006CCD80 /* Constants */,
 				D02D363E1F7FE58600D4E674 /* Coordinator */,
+				D02C22951FDE14E40024D0F6 /* CoreDataStack */,
 				D00F8F5A1F93F132006CCD80 /* HTTPClient */,
 				D09F67111F93FAA3001D910E /* Main Storyboard */,
 				D0DDEC351F7C7BC6007822CB /* Middleware */,
@@ -564,6 +575,7 @@
 				23ED5DB01FC652F6003B1BB3 /* DevotionTableViewCell.swift in Sources */,
 				2376236B1F904B290020A476 /* MBArticleDetailViewController.swift in Sources */,
 				23A278721FD10091003B2022 /* DevotionNotification.swift in Sources */,
+				D02C22971FDE15120024D0F6 /* CoreDataStack.swift in Sources */,
 				237815541FA7FF40000555B6 /* DevotionsCoordinator.swift in Sources */,
 				D02D36401F7FE5A800D4E674 /* ArticlesCoordinator.swift in Sources */,
 				D04093141FDC4969007989A1 /* ArticlePicture+CoreDataProperties.swift in Sources */,

--- a/iOS Client/ArticlesController/ArticlesCoordinator.swift
+++ b/iOS Client/ArticlesController/ArticlesCoordinator.swift
@@ -10,12 +10,14 @@ import Foundation
 import UIKit
 import ReSwift
 import SafariServices
+import CoreData
 
 class ArticlesCoordinator: NSObject, Coordinator, StoreSubscriber, UINavigationControllerDelegate, SFSafariViewControllerDelegate {
     var childCoordinators: [Coordinator] = []
     var route: [RouteComponent] = [.base]
     var tab: Tab = .articles
     var overlay: URL? = nil
+    let managedObjectContext: NSManagedObjectContext
     
     var rootViewController: UIViewController {
         return self.navigationController
@@ -25,9 +27,15 @@ class ArticlesCoordinator: NSObject, Coordinator, StoreSubscriber, UINavigationC
         return UINavigationController()
     }()
     
+    init(managedObjectContext: NSManagedObjectContext) {
+        self.managedObjectContext = managedObjectContext
+        super.init()
+    }
+    
     // MARK: - Coordinator
     func start() {
         let articlesController = MBArticlesViewController.instantiateFromStoryboard()
+        articlesController.managedObjectContext = self.managedObjectContext
         self.navigationController.pushViewController(articlesController, animated: true)
         MBStore.sharedStore.subscribe(self)
     }

--- a/iOS Client/CoreDataStack/CoreDataStack.swift
+++ b/iOS Client/CoreDataStack/CoreDataStack.swift
@@ -1,0 +1,45 @@
+//
+//  CoreDataStack.swift
+//  iOS Client
+//
+//  Created by Alex Ramey on 12/10/17.
+//  Copyright © 2017 Mockingbird. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+class CoreDataStack {
+    private let modelName: String
+    
+    init(modelName: String) {
+        self.modelName = modelName
+    }
+    
+    private lazy var storeContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: self.modelName)
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                print("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    lazy var managedContext: NSManagedObjectContext = {
+        return self.storeContainer.viewContext
+    }()
+    
+    lazy var privateQueueContext: NSManagedObjectContext = {
+       return self.storeContainer.newBackgroundContext()
+    }()
+    
+    func saveContext() {
+        guard managedContext.hasChanges else { return }
+        do {
+            try managedContext.save()
+        } catch let error as NSError {
+            print("Unresolved error \(error), \(error.userInfo)")
+        }
+    }
+}

--- a/iOS Client/Store/MBArticlesStore.swift
+++ b/iOS Client/Store/MBArticlesStore.swift
@@ -131,6 +131,7 @@ class MBArticlesStore: NSObject {
             }
             
             var isNewData = false
+            var caughtError: Error? = nil
             // data is an array of Data, where each datum is a serialized array representing a page of results
             // thus, think of data as an array of results pages
             for jsonData in data {
@@ -140,11 +141,15 @@ class MBArticlesStore: NSObject {
                                                    deserializeFunc: deserializeFunc) || isNewData
                 } catch {
                     print("could not handle data: \(error) \(error.localizedDescription)")
-                    completion(false, error)
+                    caughtError = error
                 }
             }
             
-            completion(isNewData, nil)
+            if let error = caughtError {
+                completion(nil, error)
+            } else {
+                completion(isNewData, nil)
+            }
         }
     }
     

--- a/iOS Client/Store/MBArticlesStore.swift
+++ b/iOS Client/Store/MBArticlesStore.swift
@@ -17,72 +17,78 @@ class MBArticlesStore: NSObject {
         super.init()
     }
     
-    /***** Read Data from Core Data (Only Invoke These From The Main Thread) *****/
-    func getAuthors(persistentContainer: NSPersistentContainer) -> [MBAuthor] {
+    /***** Read from Core Data *****/
+    func getAuthors(managedObjectContext: NSManagedObjectContext) -> [MBAuthor] {
         let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: MBAuthor.entityName)
-        return performFetch(managedContext: persistentContainer.viewContext, fetchRequest: fetchRequest) as? [MBAuthor] ?? []
+        return performFetch(managedContext: managedObjectContext, fetchRequest: fetchRequest) as? [MBAuthor] ?? []
     }
     
-    func getCategories(persistentContainer: NSPersistentContainer) -> [MBCategory] {
+    func getCategories(managedObjectContext: NSManagedObjectContext) -> [MBCategory] {
         let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: MBCategory.entityName)
-        return performFetch(managedContext: persistentContainer.viewContext, fetchRequest: fetchRequest) as? [MBCategory] ?? []
+        return performFetch(managedContext: managedObjectContext, fetchRequest: fetchRequest) as? [MBCategory] ?? []
     }
     
-    func getArticles(persistentContainer: NSPersistentContainer) -> [MBArticle] {
+    func getArticles(managedObjectContext: NSManagedObjectContext) -> [MBArticle] {
         let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: MBArticle.entityName)
-        return performFetch(managedContext: persistentContainer.viewContext, fetchRequest: fetchRequest) as? [MBArticle] ?? []
+        return performFetch(managedContext: managedObjectContext, fetchRequest: fetchRequest) as? [MBArticle] ?? []
     }
     
     private func performFetch(managedContext: NSManagedObjectContext, fetchRequest: NSFetchRequest<NSManagedObject>) -> [NSManagedObject] {
-        do {
-            return try managedContext.fetch(fetchRequest)
-        } catch let error as NSError {
-            print("Could not fetch. \(error), \(error.userInfo)")
-            return []
+        var retVal: [NSManagedObject] = []
+        
+        managedContext.performAndWait {
+            do {
+                retVal = try managedContext.fetch(fetchRequest)
+            } catch let error as NSError {
+                print("Could not fetch. \(error), \(error.userInfo)")
+                retVal = []
+            }
         }
+        
+        return retVal
     }
     
-    /***** Download Data from Network (MAY BE INVOKED FROM ANY THREAD) *****/
-    func syncAllData(persistentContainer: NSPersistentContainer, completion: @escaping (Bool?, Error?) -> Void) {
+    /***** Download Data from Network *****/
+    func syncAllData(managedObjectContext: NSManagedObjectContext, completion: @escaping (Bool?, Error?) -> Void) {
         var isNewData: Bool = false
-        downloadAuthors(persistentContainer: persistentContainer) { (isNewAuthorData, authorsErr) in
+        downloadAuthors(managedObjectContext: managedObjectContext) { (isNewAuthorData, authorsErr) in
             if let unwrappedAuthorsErr = authorsErr {
                 print("There was an error downloading author data! \(unwrappedAuthorsErr)")
                 completion(nil, authorsErr)
             } else {
-                self.downloadCategories(persistentContainer: persistentContainer, completion: { (isNewCategoryData, catErr) in
+                self.downloadCategories(managedObjectContext: managedObjectContext, completion: { (isNewCategoryData, catErr) in
                     if let unwrappedCatErr = catErr {
                         print("There was an error downloading category data! \(unwrappedCatErr)")
                         completion(nil, catErr)
                     } else {
-                        self.linkCategoriesTogether(persistentContainer: persistentContainer, completion: { (linkErr) in
-                            if let unwrappedLinkErr = linkErr {
-                                print("There was an error linking categories! \(unwrappedLinkErr)")
-                                completion(nil, linkErr)
-                            } else {
-                                self.downloadArticles(persistentContainer: persistentContainer, completion: { (isNewArticleData, articleErr) in
-                                    isNewData = isNewAuthorData ?? false || isNewCategoryData ?? false || isNewArticleData ?? false
+                        if let linkErr = self.linkCategoriesTogether(managedObjectContext: managedObjectContext) {
+                            print("There was an error linking categories! \(linkErr)")
+                            completion(nil, linkErr)
+                        } else {
+                                self.downloadArticles(managedObjectContext: managedObjectContext, completion: { (isNewArticleData, articleErr) in
                                     if let unwrappedArticleErr = articleErr {
                                         print("There was an error downloading article data! \(unwrappedArticleErr)")
                                         completion(nil, articleErr)
                                     } else {
+                                        isNewData = isNewAuthorData ?? false || isNewCategoryData ?? false || isNewArticleData ?? false
                                         completion(isNewData, nil)
                                     }
                                 })
                             }
-                        })
-                    }
+                        }
                 })
             }
         }
     }
     
-    private func linkCategoriesTogether(persistentContainer: NSPersistentContainer, completion: @escaping (Error?) -> Void) {
-        persistentContainer.performBackgroundTask { (managedContext) in
-            let fetchRequest: NSFetchRequest<MBCategory> = MBCategory.fetchRequest()
-            fetchRequest.sortDescriptors = [NSSortDescriptor(key: "parentID", ascending: true)]
+    private func linkCategoriesTogether(managedObjectContext: NSManagedObjectContext) -> Error? {
+        let fetchRequest: NSFetchRequest<MBCategory> = MBCategory.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "parentID", ascending: true)]
+        
+        var caughtError: Error? = nil
+        managedObjectContext.performAndWait {
             do {
-                let fetchedCategories = try managedContext.fetch(fetchRequest) as [MBCategory]
+                let fetchedCategories = try managedObjectContext.fetch(fetchRequest) as [MBCategory]
                 var categoriesByID = [Int32: MBCategory]()
                 fetchedCategories.forEach({ (category) in
                     categoriesByID[category.categoryID] = category
@@ -90,111 +96,88 @@ class MBArticlesStore: NSObject {
                 fetchedCategories.forEach({ (category) in
                     category.parent = categoriesByID[category.parentID]
                 })
-                try managedContext.save()
-                completion(nil)
+                try managedObjectContext.save()
             } catch {
-                print("Could not fetch. \(error)")
-                completion(error)
+                print("Could not fetch. \(error) \(error.localizedDescription)")
+                caughtError = error
             }
         }
+        
+        return caughtError
     }
     
-    private func downloadAuthors(persistentContainer: NSPersistentContainer, completion: @escaping (Bool?, Error?) -> Void) {
-        performDownload(clientFunction: client.getAuthorsWithCompletion, persistentContainer: persistentContainer, deserializeFunc: MBAuthor.deserialize, completion: completion)
+    private func downloadAuthors(managedObjectContext: NSManagedObjectContext, completion: @escaping (Bool?, Error?) -> Void) {
+        performDownload(clientFunction: client.getAuthorsWithCompletion, managedObjectContext: managedObjectContext, deserializeFunc: MBAuthor.deserialize, completion: completion)
     }
     
-    private func downloadCategories(persistentContainer: NSPersistentContainer, completion: @escaping (Bool?, Error?) -> Void) {
-        performDownload(clientFunction: client.getCategoriesWithCompletion, persistentContainer: persistentContainer, deserializeFunc: MBCategory.deserialize, completion: completion)
+    private func downloadCategories(managedObjectContext: NSManagedObjectContext, completion: @escaping (Bool?, Error?) -> Void) {
+        performDownload(clientFunction: client.getCategoriesWithCompletion, managedObjectContext: managedObjectContext, deserializeFunc: MBCategory.deserialize, completion: completion)
     }
     
-    private func downloadArticles(persistentContainer: NSPersistentContainer, completion: @escaping (Bool?, Error?) -> Void) {
-        performDownload(clientFunction: client.getArticlesWithCompletion, persistentContainer: persistentContainer, deserializeFunc: MBArticle.deserialize, completion: completion)
+    private func downloadArticles(managedObjectContext: NSManagedObjectContext, completion: @escaping (Bool?, Error?) -> Void) {
+        performDownload(clientFunction: client.getArticlesWithCompletion, managedObjectContext: managedObjectContext, deserializeFunc: MBArticle.deserialize, completion: completion)
     }
     
     // An internal helper function to perform a download
-    private func performDownload(clientFunction: (@escaping ([Data], Error?) -> Void) -> (),
-                                 persistentContainer: NSPersistentContainer,
+    private func performDownload(clientFunction: (@escaping ([Data], Error?) -> Void) -> Void,
+                                 managedObjectContext: NSManagedObjectContext,
                                  deserializeFunc: @escaping (NSDictionary, NSManagedObjectContext) throws -> Bool,
                                  completion: @escaping (Bool?, Error?) -> Void) {
         
-        var newDataFlag: Bool = false
         clientFunction { (data: [Data], err: Error?) in
             if let clientErr = err {
                 completion(false, clientErr)
                 return
             }
             
-            // This serialQueue enables us to be certain only to invoke the completion handler once
-            // It also guards us from race conditions when writing to the numHandled variable
-            let serialQueue = DispatchQueue(label: "syncpoint")
-            var numHandled = 0
-            var hasReturned = false
-            
-            // data is an array of Data, where each datum is a serialized array
-            // thus, think of data as an array of arrays of objects
+            var isNewData = false
+            // data is an array of Data, where each datum is a serialized array representing a page of results
+            // thus, think of data as an array of results pages
             for jsonData in data {
                 do {
-                    try self.downloadModelsHandler(persistentContainer: persistentContainer,
+                    isNewData = try self.downloadModelsHandler(managedObjectContext: managedObjectContext,
                                                    data: jsonData,
-                                                   deserializeFunc: deserializeFunc,
-                                                   completion: { (isNewData: Bool?, err: Error?) in
-                        serialQueue.async {
-                            if !hasReturned {
-                                if err != nil {
-                                    completion(nil, err)
-                                    hasReturned = true
-                                } else {
-                                    if let isNewDataUnwrapped = isNewData, isNewDataUnwrapped == true {
-                                        newDataFlag = true
-                                    }
-                                    numHandled += 1
-                                    if numHandled == data.count {
-                                        completion(newDataFlag, nil)
-                                    }
-                                }
-                            }
-                        }
-                    })
+                                                   deserializeFunc: deserializeFunc) || isNewData
                 } catch {
-                    serialQueue.async {
-                        if !hasReturned {
-                            completion(nil, error)
-                            hasReturned = true
-                        }
-                    }
+                    print("could not handle data: \(error) \(error.localizedDescription)")
+                    completion(false, error)
                 }
             }
+            
+            completion(isNewData, nil)
         }
     }
     
     // An internal helper that returns a handler which saves the json array as a group of core data objects
-    private func downloadModelsHandler(persistentContainer: NSPersistentContainer,
+    private func downloadModelsHandler(managedObjectContext: NSManagedObjectContext,
                                        data: Data,
-                                       deserializeFunc: @escaping (NSDictionary, NSManagedObjectContext) throws -> Bool,
-                                       completion: @escaping (Bool?, Error?) -> Void) throws {
-        
-        var json : Any
-        var isNewData: Bool = false
+                                       deserializeFunc: @escaping (NSDictionary, NSManagedObjectContext) throws -> Bool) throws -> Bool {
         
         // deserialize data into the managed context and save it
-        json = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+        let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
         if let arr = json as? [NSDictionary] {
-            persistentContainer.performBackgroundTask({ (managedContext) in
+            var isNewData: Bool = false
+            var caughtError: Error? = nil
+            
+            managedObjectContext.performAndWait {
                 do {
-                    managedContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
                     try arr.forEach({ (json: NSDictionary) in
-                        if try deserializeFunc(json, managedContext) {
+                        if try deserializeFunc(json, managedObjectContext) {
                             isNewData = true
                         }
                     })
                     
-                    try managedContext.save()
-                    
-                    completion(isNewData, nil)
+                    try managedObjectContext.save()
                 } catch {
-                    completion(nil, error)
+                   caughtError = error
                 }
-            })
+            }
+            
+            if let error = caughtError {
+                throw MBDeserializationError.contextInsertionError(msg: "an unexpected error occurred: \(error) :\(error.localizedDescription)")
+            }
+            
+            return isNewData
         } else {
             throw MBDeserializationError.contractMismatch(msg: "unable to cast json object into an array of NSDictionary objects")
         }

--- a/iOS Client/TabController/AppCoordinator.swift
+++ b/iOS Client/TabController/AppCoordinator.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreData
 import UIKit
 import ReSwift
 
@@ -21,6 +22,7 @@ class AppCoordinator: NSObject, Coordinator, UITabBarControllerDelegate, StoreSu
     }
     
     let window: UIWindow
+    let managedObjectContext: NSManagedObjectContext
     
     private lazy var tabBarController: MBTabBarController = {
         let tabBarController = MBTabBarController.instantiateFromStoryboard()
@@ -28,8 +30,9 @@ class AppCoordinator: NSObject, Coordinator, UITabBarControllerDelegate, StoreSu
         return tabBarController
     }()
     
-    init(window: UIWindow) {
+    init(window: UIWindow, managedObjectContext: NSManagedObjectContext) {
         self.window = window
+        self.managedObjectContext = managedObjectContext
         super.init()
         self.window.rootViewController = self.rootViewController
         self.window.makeKeyAndVisible()
@@ -38,7 +41,7 @@ class AppCoordinator: NSObject, Coordinator, UITabBarControllerDelegate, StoreSu
     // MARK: - Coordinator
     func start() {
         MBStore.sharedStore.subscribe(self)
-        self.tabBarController.viewControllers = [ArticlesCoordinator(), BookmarksCoordinator(), DevotionsCoordinator()].map({(coord: Coordinator) -> UIViewController in
+        self.tabBarController.viewControllers = [ArticlesCoordinator(managedObjectContext: self.managedObjectContext), BookmarksCoordinator(), DevotionsCoordinator()].map({(coord: Coordinator) -> UIViewController in
             coord.start()
             self.addChildCoordinator(childCoordinator: coord)
             return coord.rootViewController


### PR DESCRIPTION
This still needs manual testing to verify nothing is broken with normal app usage and also background app refresh.

It seems that mockingbird's https is down (SSL cert issue) at the moment, and when I hit the regular http: endpoint, the Wordpress api isn't returning the paging headers . . . so I guess we hope it's fixed soon?