### PR TITLE
Hotfix: HTTP and X-WP-TotalPages Header Casing

### DIFF
--- a/iOS Client/HTTPClient/MBClient.swift
+++ b/iOS Client/HTTPClient/MBClient.swift
@@ -13,12 +13,12 @@ class MBClient: NSObject {
     private let session: URLSession
     
     // Endpoints
-    private let baseURL = "https://www.mbird.com/wp-json/wp/v2"
+    private let baseURL = "http://www.mbird.com/wp-json/wp/v2"
     private let articlesEndpoint = "/posts"
     private let categoriesEndpoint = "/categories"
     private let authorsEndpoint = "/users"
     private let mediaEndpoint = "/media"
-    private let mockingPulpitEndpoint = "https://www.mbird.com/feed/podcast/"
+    private let mockingPulpitEndpoint = "http://www.mbird.com/feed/podcast/"
     private let numResultsPerPage = 20
     private let urlArgs: String
     
@@ -214,7 +214,7 @@ class MBClient: NSObject {
             return
         }
         
-        guard let wpTotalPages = httpResponse.allHeaderFields["x-wp-totalpages"] as? String, let numPages = Int(wpTotalPages) else {
+        guard let wpTotalPages = httpResponse.allHeaderFields["X-WP-TotalPages"] as? String, let numPages = Int(wpTotalPages) else {
             completion([], NetworkRequestError.missingResponseHeaders(msg: "x-wp-totalpages header was missing"))
             return
         }

--- a/iOS Client/HTTPClient/MBClient.swift
+++ b/iOS Client/HTTPClient/MBClient.swift
@@ -214,7 +214,16 @@ class MBClient: NSObject {
             return
         }
         
-        guard let wpTotalPages = httpResponse.allHeaderFields["X-WP-TotalPages"] as? String, let numPages = Int(wpTotalPages) else {
+        var filteredKeys = httpResponse.allHeaderFields.keys.filter { (key) -> Bool in
+            guard let strKey = key as? String else {
+                return false
+            }
+            return strKey.lowercased() == "x-wp-totalpages"
+        }
+        
+        guard filteredKeys.count > 0,
+              let wpTotalPages = httpResponse.allHeaderFields[filteredKeys[0]] as? String,
+              let numPages = Int(wpTotalPages) else {
             completion([], NetworkRequestError.missingResponseHeaders(msg: "x-wp-totalpages header was missing"))
             return
         }

--- a/iOS Client/Info.plist
+++ b/iOS Client/Info.plist
@@ -54,6 +54,18 @@
                 <key>NSTemporaryExceptionMinimumTLSVersion</key>
                 <string>TLSv1.1</string>
             </dict>
+            <key>mbird.com</key>
+            <dict>
+                <!--Include to allow subdomains-->
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <!--Include to allow HTTP requests-->
+                <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <!--Include to specify minimum TLS version-->
+                <key>NSTemporaryExceptionMinimumTLSVersion</key>
+                <string>TLSv1.1</string>
+            </dict>
         </dict>
     </dict>
 </dict>


### PR DESCRIPTION
1. HTTP for now; We want to launch with HTTPS but that's not really in our control 

2. The casing on the X-WP-TotalPages response header changed. It scares me how brittle our code was. As a result, I wrote logic to check for any case of that string instead of just hard-coding an expected match.