### PR TITLE
Notification Enhancements

### DIFF
--- a/iOS Client/Constants/MBConstants.swift
+++ b/iOS Client/Constants/MBConstants.swift
@@ -12,5 +12,6 @@ struct MBConstants {
     static let SECONDS_IN_A_WEEK: Double = 7*24*3600
     static let SECONDS_IN_A_DAY: Double = 24*3600
     static let MAX_ARTICLES_ON_DEVICE: Int = 200
+    static let DEVOTION_NOTIFICATION_WINDOW_SIZE = 50
     // swiftlint:enable identifier_name
 }

--- a/iOS Client/DevotionsController/DevotionsCoordinator.swift
+++ b/iOS Client/DevotionsController/DevotionsCoordinator.swift
@@ -128,10 +128,14 @@ class DevotionsCoordinator: NSObject, Coordinator, StoreSubscriber, UNUserNotifi
 
 extension Date
 {
+    static let ddMMFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM-dd"
+        return formatter
+    }()
+
     func toMMddString() -> String
     {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MM-dd"
-        return dateFormatter.string(from: self)
+        return Date.ddMMFormatter.string(from: self)
     }
 }

--- a/iOS Client/DevotionsController/DevotionsCoordinator.swift
+++ b/iOS Client/DevotionsController/DevotionsCoordinator.swift
@@ -28,6 +28,7 @@ class DevotionsCoordinator: NSObject, Coordinator, StoreSubscriber, UNUserNotifi
         let devotionsController = MBDevotionsViewController.instantiateFromStoryboard()
         navigationController.pushViewController(devotionsController, animated: true)
         MBStore.sharedStore.subscribe(self)
+        UNUserNotificationCenter.current().delegate = self
         let devotions = devotionsStore.getDevotions()
         if devotions.count == 0 {
             devotionsStore.syncDevotions { syncedDevotions, error in
@@ -36,45 +37,56 @@ class DevotionsCoordinator: NSObject, Coordinator, StoreSubscriber, UNUserNotifi
                         MBStore.sharedStore.dispatch(LoadedDevotions(devotions: Loaded.error))
                     } else if let newDevotions = syncedDevotions {
                         MBStore.sharedStore.dispatch(LoadedDevotions(devotions: Loaded.loaded(data: newDevotions)))
-                        self.promptForNotifications()
+                        self.promptForNotifications(withDevotions: newDevotions)
                     }
                 }
             }
         } else {
             MBStore.sharedStore.dispatch(LoadedDevotions(devotions: Loaded.loaded(data: devotions)))
-            self.promptForNotifications()
+            self.promptForNotifications(withDevotions: devotions)
         }
     }
     
-    func promptForNotifications() {
-        let scheduled = UserDefaults().bool(forKey: "scheduledNotifications")
-        if !scheduled{
-            let center = UNUserNotificationCenter.current()
-            center.requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
-                if granted {
-                    let devotions = self.devotionsStore.getDevotions()
-                    self.scheduleNotifications(devotions: devotions)
-                    UserDefaults().set(true, forKey: "scheduledNotifications")
-                } else {
-                    print(error)
-                }
+    func promptForNotifications(withDevotions devotions: [LoadedDevotion]) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+            if granted {
+                self.scheduleNotifications(withCenter: center, forDevotions: devotions)
+            } else {
+                print(error)
             }
         }
     }
     
-    func scheduleNotifications(devotions: [LoadedDevotion]) {
+    func scheduleNotifications(withCenter center: UNUserNotificationCenter, forDevotions devotions: [LoadedDevotion]) {
         print("scheduling notifications")
-        let center = UNUserNotificationCenter.current()
-        center.removeAllPendingNotificationRequests()
-        
-        devotions.forEach { devotion in
-            guard let dateComponents = devotion.dateComponentsForNotification else {
+
+        center.getPendingNotificationRequests { (requests) in
+            let startDate = Date().toMMddString()
+            let sortedDevotions = devotions.sorted {$0.date < $1.date}
+            guard let startIndex = (sortedDevotions.index { $0.dateAsMMdd == startDate }) else {
                 return
             }
-            let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-            let content = DevotionNotificationContent(devotion: devotion)
-            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
-            center.add(request)
+            
+            var i = startIndex
+            var outstandingNotifications: Int = 0
+            
+            while outstandingNotifications < MBConstants.DEVOTION_NOTIFICATION_WINDOW_SIZE {
+                outstandingNotifications += 1
+                
+                let devotion = sortedDevotions[i]
+                let notificationId = "daily-devotion-\(devotion.dateAsMMdd)"
+                
+                if let dateComponents = devotion.dateComponentsForNotification,
+                    !requests.contains(where: {$0.identifier == notificationId}) {
+                    let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+                    let content = DevotionNotificationContent(devotion: devotion)
+                    let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: trigger)
+                    center.add(request)
+                }
+                
+                i = (i + 1) % sortedDevotions.count
+            }
         }
     }
     
@@ -89,11 +101,37 @@ class DevotionsCoordinator: NSObject, Coordinator, StoreSubscriber, UNUserNotifi
     
     // MARK: - UNNotificationDelegate
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
+            selectTodaysDevotion()
+        } else {
+            // user dismissed notification
+        }
+        
+        // notify the system that we're done
+        completionHandler()
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler(UNNotificationPresentationOptions.alert)
+    }
+    
+    private func selectTodaysDevotion() {
         let devotions = devotionsStore.getDevotions()
-        let date = Date()
-        if let devotion = devotions.first(where: { $0.date == LoadedDevotion.devotionDateFormatter.string(from: date) }) {
+        MBStore.sharedStore.dispatch(LoadedDevotions(devotions: .loaded(data: devotions)))
+        
+        if let devotion = devotions.first(where: {$0.dateAsMMdd == Date().toMMddString()}) {
             MBStore.sharedStore.dispatch(SelectedDevotion(devotion: devotion))
         }
-        MBStore.sharedStore.dispatch(LoadedDevotions(devotions: .loaded(data: devotions)))
+    }
+}
+
+extension Date
+{
+    func toMMddString() -> String
+    {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM-dd"
+        return dateFormatter.string(from: self)
     }
 }

--- a/iOS Client/Models/MBDevotion.swift
+++ b/iOS Client/Models/MBDevotion.swift
@@ -23,17 +23,24 @@ struct LoadedDevotion: Codable, Detailable {
     var verseText: String
     var read: Bool
     
-    init(devotion: MBDevotion, read: Bool) {
-        date = devotion.date
-        text = devotion.text
-        verse = devotion.verse
-        verseText = devotion.verseText
-        self.read = read
+    static let calendar: NSCalendar? = {
+        return NSCalendar.init(calendarIdentifier: NSCalendar.Identifier.gregorian)
+    }()
+    
+    static let devotionDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+    
+    static func getMonth(fromInt: Int) -> String {
+        return LoadedDevotion.devotionDateFormatter.monthSymbols[fromInt-1]
     }
     
     var day: Date? {
         return LoadedDevotion.devotionDateFormatter.date(from: self.date)
     }
+    
     var formattedMonthDay: String? {
         if let date = self.day, let day = LoadedDevotion.calendar?.components(.day, from: date).day {
             return String(describing: day)
@@ -49,10 +56,6 @@ struct LoadedDevotion: Codable, Detailable {
         }
     }
     
-    static func getMonth(fromInt: Int) -> String {
-        return LoadedDevotion.devotionDateFormatter.monthSymbols[fromInt-1]
-    }
-    
     var dateComponentsForNotification: DateComponents? {
         guard let devotionDay = LoadedDevotion.devotionDateFormatter.date(from: self.date), let calendar = LoadedDevotion.calendar else {
             return nil
@@ -65,13 +68,15 @@ struct LoadedDevotion: Codable, Detailable {
         return dateComponents
     }
     
-    private static let calendar: NSCalendar? = {
-        return NSCalendar.init(calendarIdentifier: NSCalendar.Identifier.gregorian)
-    }()
+    var dateAsMMdd: String {
+        return String(self.date.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: true)[1])
+    }
     
-    static let devotionDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }()
+    init(devotion: MBDevotion, read: Bool) {
+        date = devotion.date
+        text = devotion.text
+        verse = devotion.verse
+        verseText = devotion.verseText
+        self.read = read
+    }
 }


### PR DESCRIPTION
0. Explicitly registered devotions coordinator as delegate to the notification center
1. Schedule only up to 50 notifications at once (and look to advance the window every time the app launches)
2. Added foreground notification handling to still show the notification when the app is in the foreground