### PR TITLE
Fetch and nuke

### DIFF
--- a/iOS Client.xcodeproj/project.pbxproj
+++ b/iOS Client.xcodeproj/project.pbxproj
@@ -537,7 +537,7 @@
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
-								enabled = 1;
+								enabled = 0;
 							};
 						};
 					};

--- a/iOS Client.xcodeproj/project.pbxproj
+++ b/iOS Client.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		D09496481F93E79C004ACA4E /* MBConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09496471F93E79C004ACA4E /* MBConstants.swift */; };
 		D0B8BBB22134F55B00355D4B /* Bookmark+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8BBB02134F55B00355D4B /* Bookmark+CoreDataClass.swift */; };
 		D0B8BBB32134F55B00355D4B /* Bookmark+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B8BBB12134F55B00355D4B /* Bookmark+CoreDataProperties.swift */; };
+		D0DD187221377675008A24C9 /* AuthorDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DD187121377675008A24C9 /* AuthorDTO.swift */; };
+		D0DD187421377AEF008A24C9 /* CategoryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DD187321377AEF008A24C9 /* CategoryDTO.swift */; };
 		D0DDEC3B1F7C8129007822CB /* MBBookmarksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DDEC3A1F7C8129007822CB /* MBBookmarksViewController.swift */; };
 		D0DED1FE1FDC3AC100F48E8C /* MBArticle+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DED1FD1FDC3AC100F48E8C /* MBArticle+CoreDataProperties.swift */; };
 		D0EA55EF20797E40005EFA7E /* FeaturedArticleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D0EA55EE20797E40005EFA7E /* FeaturedArticleTableViewCell.xib */; };
@@ -176,6 +178,8 @@
 		D09496471F93E79C004ACA4E /* MBConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MBConstants.swift; path = "iOS Client/Constants/MBConstants.swift"; sourceTree = SOURCE_ROOT; };
 		D0B8BBB02134F55B00355D4B /* Bookmark+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmark+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D0B8BBB12134F55B00355D4B /* Bookmark+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bookmark+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D0DD187121377675008A24C9 /* AuthorDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorDTO.swift; sourceTree = "<group>"; };
+		D0DD187321377AEF008A24C9 /* CategoryDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDTO.swift; sourceTree = "<group>"; };
 		D0DDEC3A1F7C8129007822CB /* MBBookmarksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBBookmarksViewController.swift; sourceTree = "<group>"; };
 		D0DED1FD1FDC3AC100F48E8C /* MBArticle+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MBArticle+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D0EA55EE20797E40005EFA7E /* FeaturedArticleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FeaturedArticleTableViewCell.xib; sourceTree = "<group>"; };
@@ -316,6 +320,8 @@
 			children = (
 				D032F1631F81695500E78333 /* MBClient.swift */,
 				D05EF17E20E07BA00066BA3E /* ArticleDTO.swift */,
+				D0DD187121377675008A24C9 /* AuthorDTO.swift */,
+				D0DD187321377AEF008A24C9 /* CategoryDTO.swift */,
 			);
 			path = HTTPClient;
 			sourceTree = "<group>";
@@ -688,6 +694,7 @@
 				D026D8DF20F1A81F00CDBF89 /* MBPodcastsStore.swift in Sources */,
 				D05EF17F20E07BA00066BA3E /* ArticleDTO.swift in Sources */,
 				23D8BB3E207C5A310057C9D5 /* PodcastFilterViewController.swift in Sources */,
+				D0DD187421377AEF008A24C9 /* CategoryDTO.swift in Sources */,
 				D02FCCAC20E83C0900F40454 /* Image.swift in Sources */,
 				239251932117741B00C597A7 /* LinkButton.swift in Sources */,
 				D02FCCAE20E9487100F40454 /* Debouncer.swift in Sources */,
@@ -705,6 +712,7 @@
 				D026D8E220F1A81F00CDBF89 /* MBDevotionsStore.swift in Sources */,
 				D05EF18320E0827E0066BA3E /* Author.swift in Sources */,
 				D05EF18B20E095C40066BA3E /* SearchResultTableViewCell.swift in Sources */,
+				D0DD187221377675008A24C9 /* AuthorDTO.swift in Sources */,
 				237815541FA7FF40000555B6 /* DevotionsCoordinator.swift in Sources */,
 				D02D36401F7FE5A800D4E674 /* ArticlesCoordinator.swift in Sources */,
 				23864DE61FA6A1C10061F212 /* String.swift in Sources */,

--- a/iOS Client/AppDelegate/AppDelegate.swift
+++ b/iOS Client/AppDelegate/AppDelegate.swift
@@ -93,21 +93,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UINavigationBar.appearance().titleTextAttributes = attrs
         UINavigationBar.appearance().barTintColor = UIColor.white
     }
-    
-    // MARK: - Background App Refresh
-    func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        
-        let bgq = DispatchQueue.global(qos: .utility)
-        bgq.async {
-            self.articlesStore.syncAllData().then { isNewData -> Void in
-                if isNewData {
-                    completionHandler(.newData)
-                } else {
-                    completionHandler(.noData)
-                }
-            }.catch { _ in
-                completionHandler(.failed)
-            }
-        }
-    }
 }

--- a/iOS Client/ArticlesController/MBArticlesViewController.swift
+++ b/iOS Client/ArticlesController/MBArticlesViewController.swift
@@ -183,7 +183,7 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
             self.tableView.contentOffset = CGPoint(x: 0, y: -self.refreshControl.frame.size.height)
             
             self.refreshControl.beginRefreshing()
-            self.refreshTableView(self.refreshControl)
+            self.nukeAndPave()
         }
     }
     
@@ -208,19 +208,111 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
         super.viewWillDisappear(animated)
     }
     
-    @objc private func refreshTableView(_ sender: UIRefreshControl) {
-        if sender.isRefreshing {
-            self.articlesStore.nukeAndPave().then { articles -> Void in
-                self.articles = articles
-                self.tableView.reloadData()
+    // called only once from viewDidLoad
+    private func nukeAndPave() {
+        self.articlesStore.nukeAndPave().then { _ -> Void in
+                self.loadArticleDataFromDisk()
             }
             .always {
                 self.refreshControl.endRefreshing()
             }
             .catch { _ in
+                print("nuke and pave articles failed . . .")
+        }
+    }
+    
+    // called for subsequent refreshes (user pulls down refresh control)
+    @objc private func refreshTableView(_ sender: UIRefreshControl) {
+        if sender.isRefreshing {
+            guard let currentCategory = self.category else {
+                print("there is no category")
+                self.refreshControl.endRefreshing()
+                return
+            }
+            
+            var lineage: [Int] = []
+            if currentCategory.name != MBConstants.MOST_RECENT_CATEGORY_NAME {
+                lineage = [currentCategory.id] + self.categoryDAO.getDescendentsOfCategory(cat: currentCategory).map { return $0.id}
+            }
+            
+            self.client.getRecentArticles(inCategories: lineage, offset: 0, pageSize: 10).then { recentArticles -> Void in
+                self.processCandidateArticles(recentArticles, forCategory: currentCategory)
+                }
+                .always {
+                    self.refreshControl.endRefreshing()
+                }
+                .catch { _ in
                     print("refresh articles failed . . .")
             }
         }
+    }
+    
+    private func loadMore() {
+        guard !self.isLoadingMore else { return }
+        guard let currentCategory = self.category else {
+            print("there is no category")
+            return
+        }
+        self.isLoadingMore = true
+        self.footerView?.startAnimating()
+
+        var lineage: [Int] = []
+        if currentCategory.name != MBConstants.MOST_RECENT_CATEGORY_NAME {
+            lineage = [currentCategory.id] + self.categoryDAO.getDescendentsOfCategory(cat: currentCategory).map { return $0.id}
+        }
+        
+        self.client.getRecentArticles(inCategories: lineage, offset: self.articles.count, pageSize: 20).then { recentArticles -> Void in
+                self.processCandidateArticles(recentArticles, forCategory: currentCategory)
+            }
+            .always {
+                self.isLoadingMore = false
+                self.footerView?.stopAnimating()
+            }
+            .catch { _ in
+                print("loading more articles failed . . .")
+        }
+    }
+    
+    private func processCandidateArticles(_ candidateArticles: [Article], forCategory: Category) {
+        // this is n^2 performance improvement opportunity if needed
+        var newArticles = candidateArticles.filter({ (candidateArticle) -> Bool in
+            return !self.articles.contains(where: { (existingArticle) -> Bool in
+                return existingArticle.id == candidateArticle.id
+            })
+        })
+        
+        guard newArticles.count > 0 else { return }
+        
+        for index in 0..<newArticles.count {
+            newArticles[index].resolveAuthor(dao: self.authorDAO)
+            newArticles[index].resolveCategories(dao: self.categoryDAO)
+        }
+        
+        self.client.getImagesById(newArticles.map {$0.imageId}, completion: { (images) in
+            // note n^2 performance improvement opportunity if we need it
+            for index in 0..<newArticles.count {
+                newArticles[index].image = images.first(where: { (image) -> Bool in
+                    newArticles[index].imageId == image.id
+                })
+            }
+            
+            DispatchQueue.main.async {
+                // if the results are still relevant, then add them
+                if self.category?.name ?? "" == forCategory.name {
+                    self.articles = newArticles + self.articles
+                    self.articles.sort { (articleI, articleJ) -> Bool in
+                        if let iDate = articleI.getDate(), let jDate = articleJ.getDate() {
+                            return iDate.compare(jDate) == .orderedDescending
+                        } else if articleI.getDate() != nil {
+                            return true // favor existant iDate over non-existant jDate
+                        } else {
+                            return false // favor existant jDate or consider these to be equal
+                        }
+                    }
+                    self.tableView.reloadData()
+                }
+            }
+        })
     }
     
     private func loadArticleDataFromDisk() {
@@ -236,6 +328,7 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
         }
         
         self.tableView.reloadData()
+        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
     }
     
     private func configureFeaturedCell(_ cell: FeaturedArticleTableViewCell, withArticle article: Article, atIndexPath indexPath: IndexPath) {
@@ -300,71 +393,6 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-    
-    private func loadMore() {
-//        if !self.isLoadingMore {
-//            self.isLoadingMore = true
-//            self.footerView?.startAnimating()
-//            self.loadMoreArticlesWithCompletion { () -> Void in
-//                DispatchQueue.main.async {
-//                    self.footerView?.stopAnimating()
-//                    self.isLoadingMore = false
-//                }
-//            }
-//        }
-    }
-    
-//    private func loadMoreArticlesWithCompletion(_ completion: @escaping () -> Void) {
-//        guard let currentCategory = self.category else {
-//            completion()
-//            return
-//        }
-//        var restriction: [Category] = []
-//        if currentCategory.name != MBConstants.MOST_RECENT_CATEGORY_NAME {
-//            restriction = [currentCategory] + self.categoryDAO.getDescendentsOfCategory(cat: currentCategory)
-//        }
-//        firstly {
-//            self.articlesStore.syncLatestArticles(categoryRestriction: restriction, offset: self.articles.count)
-//        }.then { isNewData -> Void in
-//                if isNewData && self.category?.name ?? "" == currentCategory.name {
-//                    DispatchQueue.main.async {
-//                        var newArticles: [Article] = []
-//
-//                        if currentCategory.name == MBConstants.MOST_RECENT_CATEGORY_NAME {
-//                            newArticles = self.articlesStore.getLatestArticles(skip: self.articles.count)
-//                        } else {
-//                            newArticles = self.articlesStore.getLatestCategoryArticles(categoryIDs: restriction.map { $0.id }, skip: self.articles.count)
-//                        }
-//
-//                        self.addMoreArticles(newArticles)
-//                    }
-//                }
-//                completion()
-//            }.catch { error in
-//                print("Error loading more articles: \(error)")
-//                completion()
-//        }
-//    }
-    
-//    private func addMoreArticles(_ newArticles: [Article]) {
-//        if newArticles.count > 0 {
-//            newArticles.forEach { (newArticle) in
-//                if !self.articles.contains { $0.id == newArticle.id } {
-//                    self.articles.append(newArticle)
-//                }
-//            }
-//            self.articles.sort { (articleI, articleJ) -> Bool in
-//                if let iDate = articleI.getDate(), let jDate = articleJ.getDate() {
-//                    return iDate.compare(jDate) == .orderedDescending
-//                } else if articleI.getDate() != nil {
-//                    return true // favor existant iDate over non-existant jDate
-//                } else {
-//                    return false // favor existant jDate or consider these to be equal
-//                }
-//            }
-//            self.tableView.reloadData()
-//        }
-//    }
     
     private func rowTypeForPath(_ indexPath: IndexPath) -> RowType {
         if indexPath.section == 0 && indexPath.row == 0 {

--- a/iOS Client/HTTPClient/AuthorDTO.swift
+++ b/iOS Client/HTTPClient/AuthorDTO.swift
@@ -1,0 +1,25 @@
+//
+//  AuthorDTO.swift
+//  iOS Client
+//
+//  Created by Alex Ramey on 8/29/18.
+//  Copyright © 2018 Mockingbird. All rights reserved.
+//
+
+import Foundation
+
+struct AuthorDTO: Codable {
+    var authorId: Int
+    var info: String
+    var name: String
+    
+    enum CodingKeys: String, CodingKey {
+        case authorId   =   "id"
+        case info       =   "description"
+        case name
+    }
+    
+    func toDomain() -> Author {
+        return Author(id: authorId, name: name, info: info)
+    }
+}

--- a/iOS Client/HTTPClient/CategoryDTO.swift
+++ b/iOS Client/HTTPClient/CategoryDTO.swift
@@ -1,0 +1,25 @@
+//
+//  CategoryDTO.swift
+//  iOS Client
+//
+//  Created by Alex Ramey on 8/29/18.
+//  Copyright © 2018 Mockingbird. All rights reserved.
+//
+
+import Foundation
+
+struct CategoryDTO: Codable {
+    var categoryId: Int
+    var parentId: Int
+    var name: String
+    
+    enum CodingKeys: String, CodingKey {
+        case categoryId   =   "id"
+        case parentId     =   "parent"
+        case name
+    }
+    
+    func toDomain() -> Category {
+        return Category(id: categoryId, name: name, parentId: parentId)
+    }
+}

--- a/iOS Client/HTTPClient/MBClient.swift
+++ b/iOS Client/HTTPClient/MBClient.swift
@@ -77,17 +77,38 @@ class MBClient: NSObject {
         }
     }
     
-    // getRecentArticlesWithCompletion makes a single URL request for recent posts
+    // getRecentArticles makes a single URL request for recent posts
     // When the response is received, it calls the completion block with the resulting data and error
-    func getRecentArticlesWithCompletion(completion: @escaping ([Data], Error?) -> Void ) {
-        let urlString = "\(baseURL)\(articlesEndpoint)?per_page=50"
-        guard let url = URL(string: urlString) else {
-            completion([], NetworkRequestError.invalidURL(url: urlString))
-            return
+    func getRecentArticles() -> Promise<Article> {
+        return Promise { fulfill, reject in
+            let urlString = "\(baseURL)\(articlesEndpoint)?per_page=100"
+            guard let url = URL(string: urlString) else {
+                reject(NetworkRequestError.invalidURL(url: urlString))
+                return
+            }
+            
+            print("firing getArticles request")
+            getDataFromURL(url) { (data, err) in
+                guard let payload = data.first, err == nil else {
+                    reject(err ?? NetworkRequestError.failedPagingRequest(msg: "no first page :("))
+                    return
+                }
+                
+                var articles: [ArticleDTO] = []
+                do {
+                    articles = try self.decoder.decode([ArticleDTO].self, from: payload)
+                } catch {
+                    reject(error)
+                    return
+                }
+                
+                let domainArticles = articles.map({ (dto) -> Article in
+                    return dto.toDomain()
+                })
+                
+                completion(domainArticles, nil)
+            }
         }
-        
-        print("firing getArticles request")
-        getDataFromURL(url, withCompletion: completion)
     }
     
     func searchArticlesWithCompletion(query: String, completion: @escaping ([Article], Error?) -> Void ) {
@@ -153,42 +174,90 @@ class MBClient: NSObject {
         }.resume()
     }
     
-    // getCategoriesWithCompletion makes a single request for the first page of category data.
+    // getCategories makes a single request for the first page of category data.
     // After this request comes back, it examines the x-wp-totalpages response header to
     // determine how many pages of data exist. It then fires off concurrent requests for all
     // pages of category data. It invokes the passed-in completion with an array of response data
     // and optionally an error if one occurred at any point in the process.
-    func getCategoriesWithCompletion(completion: @escaping ([Data], Error?) -> Void ) {
-        let urlString = "\(baseURL)\(categoriesEndpoint)\(urlArgs)"
-        let urlStringWithPageOne = "\(urlString)1"
-        guard let url = URL(string: urlStringWithPageOne) else {
-            completion([], NetworkRequestError.invalidURL(url: urlStringWithPageOne))
-            return
+    func getCategories() -> Promise<[Category]> {
+        return Promise { fulfill, reject in
+            let urlString = "\(baseURL)\(categoriesEndpoint)\(urlArgs)"
+            let urlStringWithPageOne = "\(urlString)1"
+            guard let url = URL(string: urlStringWithPageOne) else {
+                reject(NetworkRequestError.invalidURL(url: urlStringWithPageOne))
+                return
+            }
+            
+            print("firing initial getCategories request")
+            self.session.dataTask(with: url) { (data: Data?, resp: URLResponse?, err: Error?) in
+                self.pagingHandler(url: urlString, data: data, resp: resp, err: err, completion: { (pages, err) in
+                    if let err = err {
+                        reject(err)
+                        return
+                    }
+                    
+                    var categories: [CategoryDTO] = []
+                    for page in pages {
+                        do {
+                            let pageOfCategories = try self.decoder.decode([CategoryDTO].self, from: page)
+                            categories.append(contentsOf: pageOfCategories)
+                        } catch {
+                            reject(error)
+                            return
+                        }
+                    }
+                    
+                    let domainCategories = categories.map({ (dto) -> Category in
+                        return dto.toDomain()
+                    })
+                    
+                    fulfill(domainCategories)
+                })
+            }.resume()
         }
-        
-        print("firing initial getCategories request")
-        self.session.dataTask(with: url) { (data: Data?, resp: URLResponse?, err: Error?) in
-            self.pagingHandler(url: urlString, data: data, resp: resp, err: err, completion: completion)
-        }.resume()
     }
     
-    // getAuthorsWithCompletion makes a single request for the first page of author data.
+    // getAuthors makes a single request for the first page of author data.
     // After this request comes back, it examines the x-wp-totalpages response header to
     // determine how many pages of data exist. It then fires off concurrent requests for all
     // pages of author data. It invokes the passed-in completion with an array of response data
     // and optionally an error if one occurred at any point in the process.
-    func getAuthorsWithCompletion(completion: @escaping ([Data], Error?) -> Void ) {
-        let urlString = "\(baseURL)\(authorsEndpoint)\(urlArgs)"
-        let urlStringWithPageOne = "\(urlString)1"
-        guard let url = URL(string: urlStringWithPageOne) else {
-            completion([], NetworkRequestError.invalidURL(url: urlStringWithPageOne))
-            return
+    func getAuthors() -> Promise<[Author]> {
+        return Promise { fulfill, reject in
+            let urlString = "\(baseURL)\(authorsEndpoint)\(urlArgs)"
+            let urlStringWithPageOne = "\(urlString)1"
+            guard let url = URL(string: urlStringWithPageOne) else {
+                reject(NetworkRequestError.invalidURL(url: urlStringWithPageOne))
+                return
+            }
+            
+            print("firing initial getAuthors request")
+            self.session.dataTask(with: url) { (data: Data?, resp: URLResponse?, err: Error?) in
+                self.pagingHandler(url: urlString, data: data, resp: resp, err: err, completion: { (pages, err) in
+                    if let err = err {
+                        reject(err)
+                        return
+                    }
+                    
+                    var authors: [AuthorDTO] = []
+                    for page in pages {
+                        do {
+                            let pageOfAuthors = try self.decoder.decode([AuthorDTO].self, from: page)
+                            authors.append(contentsOf: pageOfAuthors)
+                        } catch {
+                            reject(error)
+                            return
+                        }
+                    }
+
+                    let domainAuthors = authors.map({ (dto) -> Author in
+                        return dto.toDomain()
+                    })
+                    
+                    fulfill(domainAuthors)
+                })
+            }.resume()
         }
-        
-        print("firing initial getAuthors request")
-        self.session.dataTask(with: url) { (data: Data?, resp: URLResponse?, err: Error?) in
-            self.pagingHandler(url: urlString, data: data, resp: resp, err: err, completion: completion)
-        }.resume()
     }
     
     func getPodcasts(for stream: PodcastStream) -> Promise<[PodcastDTO]> {

--- a/iOS Client/HTTPClient/MBClient.swift
+++ b/iOS Client/HTTPClient/MBClient.swift
@@ -79,7 +79,7 @@ class MBClient: NSObject {
     
     // getRecentArticles makes a single URL request for recent posts
     // When the response is received, it calls the completion block with the resulting data and error
-    func getRecentArticles() -> Promise<Article> {
+    func getRecentArticles() -> Promise<[Article]> {
         return Promise { fulfill, reject in
             let urlString = "\(baseURL)\(articlesEndpoint)?per_page=100"
             guard let url = URL(string: urlString) else {
@@ -106,7 +106,7 @@ class MBClient: NSObject {
                     return dto.toDomain()
                 })
                 
-                completion(domainArticles, nil)
+                fulfill(domainArticles)
             }
         }
     }

--- a/iOS Client/Info.plist
+++ b/iOS Client/Info.plist
@@ -46,11 +46,6 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-		<string>fetch</string>
-	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/iOS Client/Models/Article.swift
+++ b/iOS Client/Models/Article.swift
@@ -46,5 +46,5 @@ protocol ArticleDAO {
     func getLatestArticles(skip: Int) -> [Article]
     func getLatestCategoryArticles(categoryIDs: [Int], skip: Int) -> [Article]
     func bookmarkArticle(_ article: Article) -> Error?
-    func deleteArticles(completion: @escaping (Error) -> Void)
+    func nukeAndPave() -> Promise<[Article]>
 }

--- a/iOS Client/Models/Article.swift
+++ b/iOS Client/Models/Article.swift
@@ -42,11 +42,9 @@ struct Article {
 }
 
 protocol ArticleDAO {
-    func deleteOldArticles(completion: @escaping (Int) -> Void)
     func downloadImageURLsForArticle(_ article: Article, withCompletion completion: @escaping (URL?) -> Void)
     func getLatestArticles(skip: Int) -> [Article]
     func getLatestCategoryArticles(categoryIDs: [Int], skip: Int) -> [Article]
     func bookmarkArticle(_ article: Article) -> Error?
-    func syncAllData() -> Promise<Bool>
-    func syncLatestArticles(categoryRestriction: [Category], offset: Int) -> Promise<Bool>
+    func deleteArticles(completion: @escaping (Error) -> Void)
 }

--- a/iOS Client/Models/Core Data/MBArticle+CoreDataClass.swift
+++ b/iOS Client/Models/Core Data/MBArticle+CoreDataClass.swift
@@ -12,50 +12,6 @@ import CoreData
 
 public class MBArticle: NSManagedObject {
     static let entityName: String = "Article"
-    var uiimage: UIImage? = nil
-    
-    // deserialize accepts an NSDictionary and deserializes the object into the provided
-    // managedObjectContext. It returns an error if something goes wrong.
-    // If the article already existed, then it updates its fields from the new json
-    // values. If no article with the json's id value already existed, a new one is
-    // created and inserted into the managedContext.
-    public class func deserialize(json: NSDictionary, intoContext managedContext: NSManagedObjectContext) throws -> Bool {
-        guard let idArg = json.object(forKey: "id") as? Int else {
-            throw(MBDeserializationError.contractMismatch(msg: "unable to cast json 'id' into an Int32"))
-        }
-        
-        var (resolvedArticle, isNewData) = self.resolveOrCreateArticleById(idArg, inContext: managedContext)
-        
-        guard let article = resolvedArticle else {
-            throw(MBDeserializationError.contextInsertionError(msg: "unable to resolve article with id: \(idArg) into managed context"))
-        }
-        
-        article.setValue(json.object(forKey: "id") as? Int32, forKey: "articleID")
-        article.setValue(json.value(forKeyPath: "author") as? Int32, forKey: "authorID")
-        article.setValue(json.value(forKeyPath: "link") as? String, forKey: "link")
-        article.setValue(json.value(forKeyPath: "featured_media") as? Int32, forKey: "imageID")
-        article.setValue(json.value(forKeyPath: "title.rendered") as? String, forKey: "title")
-        article.setValue(json.value(forKeyPath: "content.rendered") as? String, forKey: "content")
-        
-        if let dateStr = json.value(forKeyPath: "date") as? String {
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-            if let timeZone = TimeZone(identifier: "America/New_York") {
-                dateFormatter.timeZone = timeZone
-            }
-            article.setValue(dateFormatter.date(from: dateStr), forKey: "date")
-        }
-        
-        if let authorID = json.object(forKey: "author") as? Int {
-            linkArticle(article, toAuthor: authorID)
-        }
-        
-        if let categoryIDs = json.object(forKey: "categories") as? [Int] {
-            linkArticle(article, toCategories: categoryIDs)
-        }
-        
-        return isNewData
-    }
     
     class func newArticle(fromArticle from: Article, inContext managedContext: NSManagedObjectContext) -> MBArticle? {
         let (article, _) = self.resolveOrCreateArticleById(from.id, inContext: managedContext)

--- a/iOS Client/Models/Core Data/MBCategory+CoreDataClass.swift
+++ b/iOS Client/Models/Core Data/MBCategory+CoreDataClass.swift
@@ -10,11 +10,10 @@
 import Foundation
 import CoreData
 
-
 public class MBCategory: NSManagedObject {
     static let entityName: String = "Category"
     
-    public class func newCategory(fromCategory from: Category, inContext managedContext: NSManagedObjectContext) -> MBCategory? {
+    class func newCategory(fromCategory from: Category, inContext managedContext: NSManagedObjectContext) -> MBCategory? {
         let predicate = NSPredicate(format: "categoryID == %d", from.id)
         let fetchRequest = NSFetchRequest<MBCategory>(entityName: self.entityName)
         fetchRequest.predicate = predicate

--- a/iOS Client/Models/Core Data/MBCategory+CoreDataClass.swift
+++ b/iOS Client/Models/Core Data/MBCategory+CoreDataClass.swift
@@ -14,19 +14,8 @@ import CoreData
 public class MBCategory: NSManagedObject {
     static let entityName: String = "Category"
     
-    // deserialize accepts an NSDictionary and deserializes the object into the provided
-    // managedObjectContext. It returns an error if something goes wrong.
-    // If the category already existed, then it updates its fields from the new json
-    // values. If no category with the json's id value already existed, a new one is
-    // created and inserted into the managedContext.
-    public class func deserialize(json: NSDictionary, intoContext managedContext: NSManagedObjectContext) throws -> Bool {
-        var isNewData: Bool = false
-        
-        guard let idArg = json.object(forKey: "id") as? Int32 else {
-            throw(MBDeserializationError.contractMismatch(msg: "unable to cast json 'id' into an Int32"))
-        }
-        
-        let predicate = NSPredicate(format: "categoryID == %d", idArg)
+    public class func newCategory(fromCategory from: Category, inContext managedContext: NSManagedObjectContext) -> MBCategory? {
+        let predicate = NSPredicate(format: "categoryID == %d", from.id)
         let fetchRequest = NSFetchRequest<MBCategory>(entityName: self.entityName)
         fetchRequest.predicate = predicate
         
@@ -35,24 +24,23 @@ public class MBCategory: NSManagedObject {
             let fetchedEntities = try managedContext.fetch(fetchRequest)
             resolvedCategory = fetchedEntities.first
         } catch {
-            throw(MBDeserializationError.fetchError(msg: "error while fetching category with id: \(idArg)"))
+            print("Error fetching category \(from.id) from core data: \(error)")
+            return nil
         }
         
         if resolvedCategory == nil {
-            print("new category!")
-            isNewData = true
             let entity = NSEntityDescription.entity(forEntityName: self.entityName, in: managedContext)!
             resolvedCategory = NSManagedObject(entity: entity, insertInto: managedContext) as? MBCategory
         }
         
         guard let category = resolvedCategory else {
-            throw(MBDeserializationError.contextInsertionError(msg: "unable to resolve category with id: \(idArg) into managed context"))
+            return nil
         }
         
-        category.setValue(json.object(forKey: "id") as? Int32, forKey: "categoryID")
-        category.setValue(json.object(forKey: "parent") as? Int32, forKey: "parentID")
-        category.setValue(json.object(forKey: "name") as? String, forKey: "name")
-        return isNewData
+        category.categoryID = Int32(from.id)
+        category.parentID = Int32(from.parentId)
+        category.name = from.name
+        return category
     }
     
     // There are multiple top-level categories (whose parentID is 0). The rest are children.

--- a/iOS Client/Store/MBArticlesStore.swift
+++ b/iOS Client/Store/MBArticlesStore.swift
@@ -142,7 +142,7 @@ class MBArticlesStore: NSObject, ArticleDAO, AuthorDAO, CategoryDAO {
     func nukeAndPave() -> Promise<[Article]> {
         return Promise { fulfill, reject in
             firstly{
-                when(fulfilled: client.getAuthors(), client.getCategories(), client.getRecentArticles())
+                when(fulfilled: client.getAuthors(), client.getCategories(), client.getRecentArticles(inCategories: [], offset: 0, pageSize: 100))
             }.then { authors, categories, articles -> Void in
                 // flush db
                 if let nukeErr = self.nuke() {

--- a/iOS Client/iOS_Client.xcdatamodeld/iOS_Client.xcdatamodel/contents
+++ b/iOS Client/iOS_Client.xcdatamodeld/iOS_Client.xcdatamodel/contents
@@ -40,7 +40,7 @@
     </entity>
     <elements>
         <element name="Article" positionX="-450" positionY="-36" width="128" height="210"/>
-        <element name="Author" positionX="-218" positionY="167" width="128" height="103"/>
+        <element name="Author" positionX="-218" positionY="167" width="128" height="105"/>
         <element name="Bookmark" positionX="-333" positionY="-54" width="128" height="180"/>
         <element name="Category" positionX="-236" positionY="-300" width="128" height="135"/>
     </elements>


### PR DESCRIPTION
Here's how this works now:

On launch, if successfully able to retrieve all authors, all categories, and first 100 most recent articles, then we nuke the Database and save the new stuff to it.

Note: Bookmarks are now off to the side so they are unaffected by this process.

Then, for both refresh and infinite scrolling, we pull from the API to RAM (and bypass core data).

For refresh, we pass an offset of 0. 
For load more, we pass an offset of current number of articles.

TODOs: 
1. save refresh articles to disk so they stay up top when switching between categories.
2. for load more, consider saving some # to disk as well (capped at something reasonable)
3. Think about the bug for the case that someone has not refreshed and loading more doesn't give them new articles (can we pass a date parameter into the query? or do we live with this until they force close?)

1&2 should be easy to accomplish by exposing a saveArticles DAO method.

code is getting a lot better so that's good.

By the way, I nixed background app refresh. We can impose some sane limits on persistence. Maybe 100 per category max or something.
