### PR TITLE
Another big improvement: Paging with date; saving most recent articles to disk

### DIFF
--- a/iOS Client/ArticlesController/MBArticlesViewController.swift
+++ b/iOS Client/ArticlesController/MBArticlesViewController.swift
@@ -235,7 +235,12 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
                 lineage = [currentCategory.id] + self.categoryDAO.getDescendentsOfCategory(cat: currentCategory).map { return $0.id}
             }
             
-            self.client.getRecentArticles(inCategories: lineage, offset: 0, pageSize: 10).then { recentArticles -> Void in
+            var afterArg: String?
+            if let latestArticle = self.articles.first, latestArticle.date != "" {
+                afterArg = latestArticle.date
+            }
+            
+            self.client.getRecentArticles(inCategories: lineage, offset: 0, pageSize: 100, before: nil, after: afterArg, asc: true).then { recentArticles -> Void in
                 self.processCandidateArticles(recentArticles, forCategory: currentCategory)
                 }
                 .always {
@@ -261,7 +266,14 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
             lineage = [currentCategory.id] + self.categoryDAO.getDescendentsOfCategory(cat: currentCategory).map { return $0.id}
         }
         
-        self.client.getRecentArticles(inCategories: lineage, offset: self.articles.count, pageSize: 20).then { recentArticles -> Void in
+        var offsetArg: Int = self.articles.count
+        var beforeArg: String?
+        if let earliestArticle = self.articles.last, earliestArticle.date != "" {
+            beforeArg = earliestArticle.date
+            offsetArg = 0 // we can use date instead
+        }
+        
+        self.client.getRecentArticles(inCategories: lineage, offset: offsetArg, pageSize: 20, before: beforeArg, after: nil, asc: false).then { recentArticles -> Void in
             self.processCandidateArticles(recentArticles, forCategory: currentCategory)
             }
             .always {

--- a/iOS Client/ArticlesController/MBArticlesViewController.swift
+++ b/iOS Client/ArticlesController/MBArticlesViewController.swift
@@ -262,7 +262,7 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
         }
         
         self.client.getRecentArticles(inCategories: lineage, offset: self.articles.count, pageSize: 20).then { recentArticles -> Void in
-                self.processCandidateArticles(recentArticles, forCategory: currentCategory)
+            self.processCandidateArticles(recentArticles, forCategory: currentCategory)
             }
             .always {
                 self.isLoadingMore = false
@@ -297,6 +297,16 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
             }
             
             DispatchQueue.main.async {
+                // it's only safe to save 'most recent' category to disk;
+                // saving articles for a specific category can cause there
+                // to be holes on the most recent view. The next paging request
+                // will assume the articles are sequential and basically
+                // mash them down, covering up other potential articles and
+                // resulting in non-productive duplicates being returned
+                if forCategory.name == MBConstants.MOST_RECENT_CATEGORY_NAME {
+                    _ = self.articlesStore.saveArticles(articles: newArticles)
+                }
+                
                 // if the results are still relevant, then add them
                 if self.category?.name ?? "" == forCategory.name {
                     self.articles = newArticles + self.articles

--- a/iOS Client/Constants/MBConstants.swift
+++ b/iOS Client/Constants/MBConstants.swift
@@ -10,7 +10,6 @@ struct MBConstants {
     // swiftlint:disable identifier_name
     static let SECONDS_IN_A_WEEK: Double = 7*24*3600
     static let SECONDS_IN_A_DAY: Double = 24*3600
-    static let MAX_ARTICLES_ON_DEVICE: Int = 2000
     static let DEVOTION_NOTIFICATION_WINDOW_SIZE = 50
     static let DEFAULTS_DAILY_DEVOTION_TIME_KEY = "DAILY_DEVOTION_TIME_KEY"
     static let SELECTED_CATEGORY_NAME_KEY = "SELECTED_CATEGORY_ID_KEY"

--- a/iOS Client/HTTPClient/MBClient.swift
+++ b/iOS Client/HTTPClient/MBClient.swift
@@ -41,7 +41,7 @@ class MBClient: NSObject {
         case failedPagingRequest(msg: String)
     }
     
-    func getRecentArticles(inCategories categories: [Int], offset: Int, pageSize: Int) -> Promise<[Article]> {
+    func getRecentArticles(inCategories categories: [Int], offset: Int, pageSize: Int, before: String?, after: String?, asc: Bool) -> Promise<[Article]> {
         return Promise { fulfill, reject in
             var categoriesArg = ""
             if categories.count > 0 {
@@ -50,7 +50,16 @@ class MBClient: NSObject {
                 }
                 categoriesArg.removeLast()
             }
-            let urlString = "\(baseURL)\(articlesEndpoint)?per_page=\(pageSize)&offset=\(offset)\(categoriesArg)"
+            var beforeArg = ""
+            if let beforeDate = before {
+                beforeArg = "&before=\(beforeDate)"
+            }
+            var afterArg = ""
+            if let afterDate = after {
+                afterArg = "&after=\(afterDate)"
+            }
+            let orderArg = "&order=" + (asc ? "asc" : "desc")
+            let urlString = "\(baseURL)\(articlesEndpoint)?per_page=\(pageSize)&offset=\(offset)\(categoriesArg)\(beforeArg)\(afterArg)\(orderArg)"
             print("URL: \(urlString)")
             
             guard let url = URL(string: urlString) else {

--- a/iOS Client/Models/Article.swift
+++ b/iOS Client/Models/Article.swift
@@ -47,4 +47,5 @@ protocol ArticleDAO {
     func getLatestCategoryArticles(categoryIDs: [Int], skip: Int) -> [Article]
     func bookmarkArticle(_ article: Article) -> Error?
     func nukeAndPave() -> Promise<[Article]>
+    func saveArticles(articles: [Article]) -> Error?
 }

--- a/iOS Client/Store/MBArticlesStore.swift
+++ b/iOS Client/Store/MBArticlesStore.swift
@@ -142,7 +142,7 @@ class MBArticlesStore: NSObject, ArticleDAO, AuthorDAO, CategoryDAO {
     func nukeAndPave() -> Promise<[Article]> {
         return Promise { fulfill, reject in
             firstly{
-                when(fulfilled: client.getAuthors(), client.getCategories(), client.getRecentArticles(inCategories: [], offset: 0, pageSize: 100))
+                when(fulfilled: client.getAuthors(), client.getCategories(), client.getRecentArticles(inCategories: [], offset: 0, pageSize: 100, before: nil, after: nil, asc: false))
             }.then { authors, categories, articles -> Void in
                 // flush db
                 if let nukeErr = self.nuke() {

--- a/iOS Client/Store/MBArticlesStore.swift
+++ b/iOS Client/Store/MBArticlesStore.swift
@@ -207,6 +207,20 @@ class MBArticlesStore: NSObject, ArticleDAO, AuthorDAO, CategoryDAO {
         return retVal
     }
     
+    func saveArticles(articles: [Article]) -> Error? {
+        var saveErr: Error?
+        self.managedObjectContext.performAndWait {
+            articles.forEach { _ = MBArticle.newArticle(fromArticle: $0, inContext: self.managedObjectContext) }
+            do {
+                try self.managedObjectContext.save()
+            } catch {
+                print("unable to save articles: \(error)")
+                saveErr = error
+            }
+        }
+        return saveErr
+    }
+    
     /***** Read from Core Data *****/
     func getArticleEntities() -> [MBArticle] {
         let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: MBArticle.entityName)


### PR DESCRIPTION
this is another big improvement . . .

when refreshing, we get up to 100 articles newer than our newest article, sorted in ascending order. Which means we get the oldest new stuff first. So, if they were more than 100 behind, they could do it again to crawl backward . . .

When loading more, we get 20 articles after the oldest.

This works well since category articles cannot pollute most recent articles, which are saved to core data.


The only drawback for now is if you navigate away from a category then back to it you have to reload whatever isn't in the DB.

A possible workaround would be to still save category articles with some type of flag that most recent can filter on. Then, if most recent every gets the same article, remove the flag.