### PR TITLE
img styling issue; cell highlighting was weird, made it normal

### DIFF
--- a/iOS Client/ArticlesController/MBArticlesViewController.swift
+++ b/iOS Client/ArticlesController/MBArticlesViewController.swift
@@ -29,8 +29,6 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
     let recentReuseIdentifier = "recentReuseIdentifier"
     let categoryArticleReuseIdentifier = "categoryArticleReuseIdentifier"
     
-    var selectedIndexPath: IndexPath?
-    
     var isLoadingMore = false
     var isFirstAppearance = true
     var footerView: UIActivityIndicatorView?
@@ -195,10 +193,6 @@ class MBArticlesViewController: UIViewController, UITableViewDelegate, UITableVi
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         controller?.enabled = true
-        if let indexPath = self.selectedIndexPath {
-            self.tableView.deselectRow(at: indexPath, animated: true)
-            self.selectedIndexPath = nil
-        }
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -488,7 +482,6 @@ extension MBArticlesViewController {
 
     // MARK: - UITableViewDelegate
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        self.selectedIndexPath = indexPath
         if let article = articleForPath(indexPath) {
             if let delegate = self.delegate {
                 var context = self.category?.name
@@ -496,6 +489,7 @@ extension MBArticlesViewController {
                     context = nil // no special context for most recent category
                 }
                 delegate.selectedArticle(article, categoryContext: context)
+                self.tableView.deselectRow(at: indexPath, animated: false)
             }
         }
     }

--- a/iOS Client/Search/SearchResultsTableViewController.swift
+++ b/iOS Client/Search/SearchResultsTableViewController.swift
@@ -59,7 +59,6 @@ class SearchResultsTableViewController: UIViewController, UISearchResultsUpdatin
         if let searchBar = self.searchBar {
             self.automaticallyAdjustsScrollViewInsets = false
             self.tableView.contentInset = UIEdgeInsets(top: searchBar.frame.size.height, left: 0.0, bottom: 0.0, right: 0.0)
-            print("CURIOUS GEORGE: \(searchBar.frame.size.height)")
         }
         
         controller = Preheat.Controller(view: self.tableView)
@@ -232,6 +231,7 @@ class SearchResultsTableViewController: UIViewController, UISearchResultsUpdatin
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if let delegate = self.delegate {
             delegate.selectedArticle(self.results[indexPath.row], categoryContext: nil)
+            self.tableView.deselectRow(at: indexPath, animated: false)
         }
     }
 }

--- a/iOS Client/Style/MB.css
+++ b/iOS Client/Style/MB.css
@@ -60,6 +60,13 @@ iframe{
     height: auto;
 }
 
+img {
+    display: block;
+    margin: auto;
+    width: 95%;
+    height: auto;
+}
+
 img.alignleft {
     float: left;
     margin: 12px;
@@ -75,13 +82,6 @@ img.alignright {
 }
 
 img.aligncenter {
-    display: block;
-    margin: auto;
-    width: 95%;
-    height: auto;
-}
-
-img.alignnone {
     display: block;
     margin: auto;
     width: 95%;


### PR DESCRIPTION
turns out CSS has some precedence rules. Using `img` as a catch-call for ones that don't have expected classes